### PR TITLE
Add responsive padding to layouts

### DIFF
--- a/src/layouts/Content.astro
+++ b/src/layouts/Content.astro
@@ -20,7 +20,7 @@ const {
 ---
 
 <Layout title={title ?? heading}>
-  <article class="prose mx-auto max-w-[48rem]">
+  <article class="prose mx-auto max-w-[48rem] px-4 sm:px-6">
     {heading && <h1 class="my-4 text-3xl font-bold">{heading}</h1>}
     {description && <p class="mb-8 text-lg text-muted">{description}</p>}
     <slot />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const pageTitle = title ? `${title} | ${site.name}` : site.name;
     >
       <Navbar />
     </header>
-    <main id="main" class="mx-auto w-full flex-1">
+    <main id="main" class="mx-auto w-full flex-1 px-4 sm:px-6">
       <slot />
     </main>
 


### PR DESCRIPTION
## Summary
- add horizontal padding to main content area in `Layout.astro`
- match padding in `Content.astro` for markdown pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96a159dcc8324b0a750f89b1fdaf5