### PR TITLE
Set initial-scale in viewport meta tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,7 @@ const pageTitle = title ? `${title} | ${site.name}` : site.name;
 <html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>


### PR DESCRIPTION
## Summary
- add `initial-scale=1` to viewport meta tag for stable mobile rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96a1c5dd883248989d6b7aec62fa4