### PR TITLE
feat: add skip link to main content

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,6 +16,7 @@ const pageTitle = title ? `${title} | ${site.name}` : site.name;
     <title>{pageTitle}</title>
   </head>
   <body class="m-0 flex min-h-full flex-col bg-bg-mid font-sans text-ink">
+    <a href="#main" class="sr-only focus:not-sr-only">Skip to content</a>
     <header
       id="site-header"
       class="sticky top-0 z-50 border-b border-soft bg-white/95 backdrop-blur transition-all duration-300 ease-out hover:translate-y-0 hover:opacity-100"


### PR DESCRIPTION
## Summary
- add screen reader skip link to jump to main content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96a28dba883249dcea7509ab43ac2