### PR TITLE
Include image densities for screen scaling

### DIFF
--- a/src/components/ImageParagraph.astro
+++ b/src/components/ImageParagraph.astro
@@ -28,6 +28,7 @@ const direction = side === "right" ? "sm:flex-row-reverse" : "sm:flex-row";
     alt={alt}
     width={width}
     height={height}
+    densities={[1, 1.5, 2]}
     class={`not-prose shrink-0 rounded object-cover`}
     style={`width:${width}px;height:auto`}
   />

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -10,7 +10,13 @@ import { Menu } from "lucide-astro";
   <!-- left cluster -->
   <div class="flex items-center">
     <a href="/" class="flex items-center text-inherit no-underline">
-      <Image src={logo} alt="The FurtherSouth logo" width="50" height="50" />
+      <Image
+        src={logo}
+        alt="The FurtherSouth logo"
+        width="50"
+        height="50"
+        densities={[1, 1.5, 2]}
+      />
       <span class="ml-2 text-xl font-bold">{site.name}</span>
     </a>
     <div class="ml-8 flex flex-col text-xs leading-tight text-slate-700">


### PR DESCRIPTION
I noticed the logo and our images looked worse than the other images, which I believe is because I use 1.5x display scaling. Adding `densities` of 1, 1.5, and 2 means a higher resolution image is loaded on 1.5x scaling, but the standard image (150x150 in the case of the staff page) on 1x scaling. 