### PR TITLE
Automatically create release on main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Archive dist
+        run: zip -r dist.zip dist
+      - name: Get short SHA
+        id: vars
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.vars.outputs.short_sha }}
+          name: Release ${{ steps.vars.outputs.short_sha }}
+          files: dist.zip


### PR DESCRIPTION
## Summary
- build and archive `dist` on pushes to `main` and create a GitHub release attaching the archive
- remove standalone build workflow
- use a shortened commit hash for release tag and name

## Testing
- `npm run build`
- `npx prettier .github/workflows/release.yml --check`


------
https://chatgpt.com/codex/tasks/task_e_68b623ac952083299351bc1c602b28df